### PR TITLE
process config in init to properly get all replace blocks

### DIFF
--- a/src/main/java/de/maxhenkel/gravestone/proxy/CommonProxy.java
+++ b/src/main/java/de/maxhenkel/gravestone/proxy/CommonProxy.java
@@ -32,13 +32,10 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Configuration;
 
 public class CommonProxy {
-
+	private Configuration cfg = null;
 	public void preinit(FMLPreInitializationEvent event) {
-		Configuration c=null;
     	try{
-			c=new Configuration(event.getSuggestedConfigurationFile());
-			Config config=new Config(c);
-			config.setInstance();
+			cfg = new Configuration(event.getSuggestedConfigurationFile());
 		}catch(Exception e){
 			Log.w("Could not create config file: " +e.getMessage());
 		}
@@ -47,6 +44,13 @@ public class CommonProxy {
 	}
 
 	public void init(FMLInitializationEvent event) {
+		try{
+			Config config=new Config(cfg);
+			config.setInstance();
+		}catch(Exception e){
+			Log.w("Could not create config file: " +e.getMessage());
+		}
+		
 		MinecraftForge.EVENT_BUS.register(new UpdateCheckEvents());
 		MinecraftForge.EVENT_BUS.register(new DeathEvents());
 		MinecraftForge.EVENT_BUS.register(new BlockEvents());

--- a/src/main/java/de/maxhenkel/gravestone/util/Tools.java
+++ b/src/main/java/de/maxhenkel/gravestone/util/Tools.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Random;
 
 import de.maxhenkel.gravestone.Config;
+import de.maxhenkel.gravestone.Log;
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
@@ -106,14 +107,12 @@ public class Tools {
 	public static Block getBlock(String name) {
 		try {
 				Block b = (Block) Block.blockRegistry.getObject(name);
-				if (b.equals(Blocks.air)) {
-					return null;
-				} else {
+				if (!b.equals(Blocks.air)) {
 					return b;
 				}
-		} catch (Exception e) {
-			return null;
-		}
+		} catch (Exception e) {}
+		Log.w("Failed to get block from name: " + name);
+		return null;
 	}
 
 	public static void dropInventoryItems(World worldIn, BlockPos pos, IInventory inv) {


### PR DESCRIPTION
some blocks from other mods (e.g. tfc aesthetics) were being loaded after gravestones loaded its config. Moved config reloading to the initialization phase. Should be no issues with the current config options but if further options are added this is perhaps not a perfect fix.

@Jerome226 can you make a build? thanks